### PR TITLE
Fix bad file path for email attachements in EmailComposer

### DIFF
--- a/src/ios/EmailComposer.m
+++ b/src/ios/EmailComposer.m
@@ -110,7 +110,9 @@
         if (attachmentPaths) {
             for (NSString* path in attachmentPaths) {
                 @try {
-                    NSData *data = [[NSFileManager defaultManager] contentsAtPath:path];
+                    NSString *documentsDirectory = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject];
+                    NSString *filePath = [documentsDirectory stringByAppendingPathComponent:path];
+                    NSData *data = [[NSFileManager defaultManager] contentsAtPath:filePath];
                     [mailComposer addAttachmentData:data mimeType:[self getMimeTypeFromFileExtension:[path pathExtension]] fileName:[NSString stringWithFormat:@"attachment%d.%@", counter, [path pathExtension]]];
                     counter++;
                 }


### PR DESCRIPTION
The error only occurred after updateing Cordova to 5.0.
